### PR TITLE
Fix `_list.scss` the Sass way

### DIFF
--- a/src/decode/types/_list.scss
+++ b/src/decode/types/_list.scss
@@ -16,7 +16,16 @@
       @if not $needs-comma {
         @return _throw("Unexpected comma in array literal.", $position);
       }
-      @return ($position + 1, $list);
+
+      // Do it the Sass way and destruct a single item
+      // array to an element.
+      // eg. ((true) (false) (false true) true) becomse (true false (false true) true)
+      @if length($list) == 1{
+        @return ($position + 1, nth($list, 1));
+      }
+      @else{
+        @return ($position + 1, $list);
+      }
     }
 
     @else if $char == "," {

--- a/test/decode/types/_list.scss
+++ b/test/decode/types/_list.scss
@@ -12,6 +12,7 @@
   @include it("should properly decode multi-dimensional arrays to nested lists") {
     @include should(expect(json-decode('[0, 1, [2, 3, [4, 5], 6]]')), to(equal(0 1 (2 3 (4 5) 6))));
     @include should(expect(json-decode('[["a", "b", ["c", "d"]], "e"]')), to(equal(("a" "b" ("c" "d")) "e")));
+    @include should(expect(json-decode('[true, false, [false, true], true]')), to(equal(true false (false true) true)));
     @include should(expect(json-decode('[[true], [false], [false, true], true]')), to(equal((true) (false) (false true) true)));
   }
 


### PR DESCRIPTION
This will fix Issue #11 and handle single item arrays the sass way and replace them with the item instead. 

So `((true) (false) (false true) true)` becomes (`true false (false true) true)`

I am unsure if this should be the way to handle it. 
